### PR TITLE
include PDFs from subdirs. symlink instead of copy. get rid of of hardcoded paths

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+*.pyc
+data/
+index/
+static/sources/

--- a/README.md
+++ b/README.md
@@ -6,4 +6,4 @@ Simple Flask web service to search through your PDF collection using Whoosh.
 - Flask
 - Xpdf
 - Whoosh
-
+- pdftotext

--- a/collect.py
+++ b/collect.py
@@ -1,11 +1,16 @@
 #! /usr/bin/python
 
 import os
+import sys
 import sh
 
 from config import SRC, PATHS
 
 for path in PATHS:
 	for filename in os.listdir(path):
-		if filename.endswith('.pdf') and not os.path.exists(os.path.join(SRC, filename)):
-			sh.ln('-s', os.path.join(path, filename), os.path.join(SRC, filename))
+		try:
+			if filename.endswith('.pdf') and not os.path.exists(os.path.join(SRC, filename)):
+				sh.ln('-s', os.path.join(path, filename), os.path.join(SRC, filename))
+		except Exception as e:
+			sys.stderr.write(u"Can't create symlink to file '{}'.\n{}".format(filename,e))
+			pass

--- a/collect.py
+++ b/collect.py
@@ -8,4 +8,4 @@ from config import SRC, PATHS
 for path in PATHS:
 	for filename in os.listdir(path):
 		if filename.endswith('.pdf') and not os.path.exists(os.path.join(SRC, filename)):
-			sh.mv(os.path.join(path, filename), os.path.join(SRC, filename))
+			sh.ln('-s', os.path.join(path, filename), os.path.join(SRC, filename))

--- a/collect.py
+++ b/collect.py
@@ -7,10 +7,11 @@ import sh
 from config import SRC, PATHS
 
 for path in PATHS:
-	for filename in os.listdir(path):
-		try:
-			if filename.endswith('.pdf') and not os.path.exists(os.path.join(SRC, filename)):
-				sh.ln('-s', os.path.join(path, filename), os.path.join(SRC, filename))
-		except Exception as e:
-			sys.stderr.write(u"Can't create symlink to file '{}'.\n{}".format(filename,e))
-			pass
+	for folder, subfolders, filenames in os.walk(path):
+		for filename in filenames:
+			try:
+				if filename.endswith('.pdf') and not os.path.exists(os.path.join(SRC, filename)):
+					sh.ln('-s', os.path.join(path, filename), os.path.join(SRC, filename))
+			except Exception as e:
+				sys.stderr.write(u"Can't create symlink to file '{}'.\n{}".format(filename.decode('utf8'),e))
+				pass

--- a/indexer.py
+++ b/indexer.py
@@ -9,7 +9,7 @@ from whoosh import index
 from whoosh.fields import Schema, TEXT, KEYWORD, ID, STORED, DATETIME
 from whoosh.analysis import StemmingAnalyzer, SimpleAnalyzer
 
-from config import ROOT, SRC, DATA
+from config import ROOT, SRC, DATA, PDFTOTEXT_PATH
 
 SCHEMA = Schema(id     = ID(stored=True),
                 path   = ID(stored=True),
@@ -24,7 +24,7 @@ def fileid(filepath):
 
 def extract_text_from_pdf(filepath):
     target = fileid(filepath)
-    subprocess.call(['/usr/local/bin/pdftotext', filepath, join(DATA, target + ".txt")])
+    subprocess.call([PDFTOTEXT_PATH, filepath, join(DATA, target + ".txt")])
     with codecs.open(join(DATA, target + ".txt")) as infile:
         return infile.read()
 

--- a/update.sh
+++ b/update.sh
@@ -1,4 +1,4 @@
 #! /bin/bash
 
-python /Users/folgert/pdfviewer/collect.py
-python /Users/folgert/pdfviewer/indexer.py
+python collect.py
+python indexer.py


### PR DESCRIPTION
Hallo Folgert,

I have made some minor changes to make your package run on my machine. The code now also indexes PDFs from subdirectories and links to them instead of making a copy. (I added a try/except block in `collect.py` because I ran into issues whenever paths were to long.)

Groetjes,
Arne
